### PR TITLE
Fix GitHub Pages deployment base path for custom domain

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
-  base: process.env.NODE_ENV === "production" ? "/interactive-tutorials/" : "/",
+  base: "/",
   server: {
     host: "0.0.0.0",
     port: 5173,


### PR DESCRIPTION
## Summary
- Fix 404 errors and MIME type issues on GitHub Pages deployment
- Correct base path configuration for custom domain hosting
- Ensure assets load properly on rfc.stonecharioteer.com

## Problem
The site was completely broken on the custom domain due to incorrect asset paths:
- CSS and JS files returned 404 errors
- MIME type errors (text/html instead of application/javascript)  
- Assets were requested from `/interactive-tutorials/assets/...` but served from `/assets/...`

## Root Cause
Custom domains on GitHub Pages serve content from root path `/`, not repository subpaths.
The Vite config was incorrectly setting `base: "/interactive-tutorials/"` for production.

## Solution
- Changed `base: process.env.NODE_ENV === "production" ? "/interactive-tutorials/" : "/"` 
- To: `base: "/"`
- This ensures assets are always requested from root path regardless of environment

## Testing
- ✅ Local build works correctly with live-server
- ✅ Production asset paths now match custom domain structure
- ✅ TypeScript build passes without errors

## Files Changed
- `frontend/vite.config.ts` - Updated base path configuration

🤖 Generated with [Claude Code](https://claude.ai/code)