### PR TITLE
Fix RFC page scroll position issue on navigation

### DIFF
--- a/frontend/src/pages/RfcDetail.tsx
+++ b/frontend/src/pages/RfcDetail.tsx
@@ -1,4 +1,5 @@
 import { useParams, Link } from "react-router-dom";
+import { useEffect } from "react";
 import { rfcs } from "../data/rfcs";
 import {
   ArrowLeft,
@@ -62,6 +63,11 @@ export default function RfcDetail() {
   const rfcNumber = parseInt(number || "0");
   const rfc = rfcs.find((r) => r.number === rfcNumber);
   const RfcComponent = rfcComponents[rfcNumber];
+
+  // Scroll to top when component mounts or RFC changes
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [rfcNumber]);
 
   if (!rfc || !RfcComponent) {
     return (


### PR DESCRIPTION
## Summary
Fixes the issue where RFC pages would scroll to the middle of the page when navigating from the main page, even on fresh visits.

## Problem
When clicking on RFC links from the home page, the destination RFC page would automatically scroll to somewhere in the middle of the content instead of starting at the top. This happened even for pages that hadn't been visited before, indicating it wasn't a browser scroll restoration issue.

## Solution
- Added `useEffect` hook to `RfcDetail` component that calls `window.scrollTo(0, 0)` when the component mounts or when the RFC number changes
- This ensures consistent page positioning and proper user experience when navigating between RFCs

## Test plan
- [x] Navigate from home page to any RFC - page should start at the top
- [x] Navigate between different RFCs - each should start at the top
- [x] Build process completes successfully
- [x] No TypeScript errors introduced

🤖 Generated with [Claude Code](https://claude.ai/code)