### PR TITLE
Fix cross-link routing URLs from /rfcs/ to /rfc/

### DIFF
--- a/frontend/src/pages/rfcs/RFC4301.tsx
+++ b/frontend/src/pages/rfcs/RFC4301.tsx
@@ -41,7 +41,7 @@ export default function RFC4301() {
       <h2>Evolution from RFC 2401</h2>
       <p>
         <strong>RFC 4301</strong> replaced{" "}
-        <Link to="/rfcs/2401" className="text-blue-600 hover:text-blue-800">
+        <Link to="/rfc/2401" className="text-blue-600 hover:text-blue-800">
           RFC 2401 (1998)
         </Link>{" "}
         with significant architectural improvements based on 7 years of real-world
@@ -376,7 +376,7 @@ graph LR
           Encapsulating Security Payload (ESP) protocol for hands-on encryption experience.
         </p>
         <Link
-          to="/rfcs/4303"
+          to="/rfc/4303"
           className="inline-flex items-center text-blue-600 hover:text-blue-800 font-medium"
         >
           RFC 4303: ESP Implementation →

--- a/frontend/src/pages/rfcs/RFC4303.tsx
+++ b/frontend/src/pages/rfcs/RFC4303.tsx
@@ -132,7 +132,7 @@ graph TD
       <h2>Security Services Provided</h2>
       <p>
         ESP can provide different combinations of security services depending
-        on configuration. <Link to="/rfcs/4301" className="text-blue-600 hover:text-blue-800">RFC 4301</Link> defines
+        on configuration. <Link to="/rfc/4301" className="text-blue-600 hover:text-blue-800">RFC 4301</Link> defines
         which combinations are mandatory and optional.
       </p>
 
@@ -557,7 +557,7 @@ graph LR
           relay mechanisms for NAT traversal in challenging network scenarios.
         </p>
         <Link
-          to="/rfcs/8656"
+          to="/rfc/8656"
           className="inline-flex items-center text-blue-600 hover:text-blue-800 font-medium"
         >
           RFC 8656: TURN Relay Protocol →

--- a/frontend/src/pages/rfcs/RFC5389.tsx
+++ b/frontend/src/pages/rfcs/RFC5389.tsx
@@ -440,7 +440,7 @@ export default function RFC5389() {
       </p>
       -{" "}
       <strong>
-        <Link to="/rfcs/8445" className="text-blue-600 hover:text-blue-800">
+        <Link to="/rfc/8445" className="text-blue-600 hover:text-blue-800">
           RFC 8445 (ICE)
         </Link>
       </strong>

--- a/frontend/src/pages/rfcs/RFC8445.tsx
+++ b/frontend/src/pages/rfcs/RFC8445.tsx
@@ -29,7 +29,7 @@ export default function RFC8445() {
         <strong>Interactive Connectivity Establishment (ICE)</strong> represents
         the evolution of NAT traversal from simple{" "}
         <strong>
-          <Link to="/rfcs/5389" className="text-blue-600 hover:text-blue-800">
+          <Link to="/rfc/5389" className="text-blue-600 hover:text-blue-800">
             STUN (RFC 5389)
           </Link>
         </strong>
@@ -492,7 +492,7 @@ export default function RFC8445() {
       applications.
       <h3>Related Protocols to Explore</h3>-{" "}
       <strong>
-        <Link to="/rfcs/5389" className="text-blue-600 hover:text-blue-800">
+        <Link to="/rfc/5389" className="text-blue-600 hover:text-blue-800">
           RFC 5389 (STUN)
         </Link>
       </strong>

--- a/frontend/src/pages/rfcs/RFC8656.tsx
+++ b/frontend/src/pages/rfcs/RFC8656.tsx
@@ -40,11 +40,11 @@ export default function RFC8656() {
       <h2>The Problem TURN Solves</h2>
       <p>
         While{" "}
-        <Link to="/rfcs/5389" className="text-blue-600 hover:text-blue-800">
+        <Link to="/rfc/5389" className="text-blue-600 hover:text-blue-800">
           STUN (RFC 5389)
         </Link>{" "}
         and{" "}
-        <Link to="/rfcs/8445" className="text-blue-600 hover:text-blue-800">
+        <Link to="/rfc/8445" className="text-blue-600 hover:text-blue-800">
           ICE (RFC 8445)
         </Link>{" "}
         enable direct peer-to-peer connections in many scenarios, some network
@@ -499,21 +499,21 @@ sequenceDiagram
         </p>
         <div className="flex flex-wrap gap-2 mt-3">
           <Link
-            to="/rfcs/5389"
+            to="/rfc/5389"
             className="inline-flex items-center text-blue-600 hover:text-blue-800 font-medium text-sm"
           >
             ← RFC 5389: STUN
           </Link>
           <span className="text-gray-400">|</span>
           <Link
-            to="/rfcs/8445"
+            to="/rfc/8445"
             className="inline-flex items-center text-blue-600 hover:text-blue-800 font-medium text-sm"
           >
             RFC 8445: ICE
           </Link>
           <span className="text-gray-400">|</span>
           <Link
-            to="/rfcs/4787"
+            to="/rfc/4787"
             className="inline-flex items-center text-blue-600 hover:text-blue-800 font-medium text-sm"
           >
             RFC 4787: NAT Behavior →


### PR DESCRIPTION
## Summary
- Fixed 12 broken cross-links across 5 RFC tutorial pages that were using incorrect `/rfcs/` URL pattern
- Corrected routing pattern inconsistency to match React Router configuration (`/rfc/:number`)
- All internal navigation between RFC pages now works properly

## Files Changed
- `RFC4301.tsx`: 2 links fixed (RFC 2401, RFC 4303)
- `RFC4303.tsx`: 2 links fixed (RFC 4301, RFC 8656) 
- `RFC5389.tsx`: 1 link fixed (RFC 8445)
- `RFC8445.tsx`: 2 links fixed (RFC 5389 references)
- `RFC8656.tsx`: 5 links fixed (RFC 5389, RFC 8445, RFC 4787)

## Test Plan
- [x] Build passes successfully (`npm run build`)
- [x] All cross-links now use correct `/rfc/{number}` pattern
- [x] Navigation between related RFC pages works properly
- [x] No broken internal links remain

🤖 Generated with [Claude Code](https://claude.ai/code)