### PR TITLE
Implement RFC visit history tracking feature

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,9 +1,10 @@
 import { Link } from "react-router-dom";
 import { rfcs, rfcEras } from "../data/rfcs";
-import { CheckCircle2, FileText, Clock, Award, BarChart3 } from "lucide-react";
+import { CheckCircle2, FileText, Clock, Award, BarChart3, Eye } from "lucide-react";
 import RfcBadge from "../components/RfcBadge";
 import SearchFilter from "../components/SearchFilter";
 import { useRfcFilter } from "../hooks/useRfcFilter";
+import { visitHistoryUtils } from "../utils/visitHistory";
 
 export default function Home() {
   const {
@@ -138,17 +139,26 @@ export default function Home() {
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {eraRfcs.map((rfc) => {
                   const isCompleted = completedRfcs.includes(rfc.number);
+                  const isVisited = visitHistoryUtils.isRfcVisited(rfc.number);
 
                   return (
                     <Link
                       key={rfc.number}
                       to={`/rfc/${rfc.number}`}
-                      className="rfc-card hover:scale-105 transform transition-all duration-200"
+                      className={`rfc-card hover:scale-105 transform transition-all duration-200 ${
+                        isCompleted 
+                          ? 'border-green-200 dark:border-green-700 bg-green-50/50 dark:bg-green-900/10'
+                          : isVisited 
+                          ? 'border-blue-200 dark:border-blue-700 bg-blue-50/50 dark:bg-blue-900/10' 
+                          : ''
+                      }`}
                     >
                       <div className="flex items-start justify-between mb-3">
                         <div className="flex items-center space-x-2">
                           {isCompleted ? (
                             <CheckCircle2 className="h-5 w-5 text-green-500" />
+                          ) : isVisited ? (
+                            <Eye className="h-5 w-5 text-blue-500" />
                           ) : (
                             <FileText className="h-5 w-5 text-gray-400 dark:text-gray-500" />
                           )}
@@ -163,7 +173,13 @@ export default function Home() {
                         </span>
                       </div>
 
-                      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+                      <h3 className={`text-lg font-semibold mb-2 ${
+                        isCompleted
+                          ? 'text-green-900 dark:text-green-100'
+                          : isVisited 
+                          ? 'text-blue-900 dark:text-blue-100' 
+                          : 'text-gray-900 dark:text-white'
+                      }`}>
                         {rfc.title}
                       </h3>
 
@@ -200,18 +216,27 @@ export default function Home() {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {filteredRfcs.map((rfc) => {
                 const isCompleted = completedRfcs.includes(rfc.number);
+                const isVisited = visitHistoryUtils.isRfcVisited(rfc.number);
                 const era = rfcEras[rfc.era];
 
                 return (
                   <Link
                     key={rfc.number}
                     to={`/rfc/${rfc.number}`}
-                    className="rfc-card hover:scale-105 transform transition-all duration-200"
+                    className={`rfc-card hover:scale-105 transform transition-all duration-200 ${
+                      isCompleted 
+                        ? 'border-green-200 dark:border-green-700 bg-green-50/50 dark:bg-green-900/10'
+                        : isVisited 
+                        ? 'border-blue-200 dark:border-blue-700 bg-blue-50/50 dark:bg-blue-900/10' 
+                        : ''
+                    }`}
                   >
                     <div className="flex items-start justify-between mb-3">
                       <div className="flex items-center space-x-2">
                         {isCompleted ? (
                           <CheckCircle2 className="h-5 w-5 text-green-500" />
+                        ) : isVisited ? (
+                          <Eye className="h-5 w-5 text-blue-500" />
                         ) : (
                           <FileText className="h-5 w-5 text-gray-400 dark:text-gray-500" />
                         )}
@@ -231,7 +256,13 @@ export default function Home() {
                       </div>
                     </div>
 
-                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+                    <h3 className={`text-lg font-semibold mb-2 ${
+                      isCompleted
+                        ? 'text-green-900 dark:text-green-100'
+                        : isVisited 
+                        ? 'text-blue-900 dark:text-blue-100' 
+                        : 'text-gray-900 dark:text-white'
+                    }`}>
                       {rfc.title}
                     </h3>
 

--- a/frontend/src/pages/RfcDetail.tsx
+++ b/frontend/src/pages/RfcDetail.tsx
@@ -9,6 +9,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import RfcBadge from "../components/RfcBadge";
+import { visitHistoryUtils } from "../utils/visitHistory";
 import RFC1 from "./rfcs/RFC1";
 import RFC675 from "./rfcs/RFC675";
 import RFC791 from "./rfcs/RFC791";
@@ -72,10 +73,15 @@ export default function RfcDetail() {
   const rfc = rfcs.find((r) => r.number === rfcNumber);
   const RfcComponent = rfcComponents[rfcNumber];
 
-  // Scroll to top when component mounts or RFC changes
+  // Scroll to top and record visit when component mounts or RFC changes
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, [rfcNumber]);
+    
+    // Record the visit if RFC exists and component is loaded
+    if (rfc && RfcComponent) {
+      visitHistoryUtils.recordVisit(rfcNumber);
+    }
+  }, [rfcNumber, rfc, RfcComponent]);
 
   if (!rfc || !RfcComponent) {
     return (

--- a/frontend/src/pages/rfcs/RFC2547.tsx
+++ b/frontend/src/pages/rfcs/RFC2547.tsx
@@ -125,7 +125,7 @@ VRF = Virtual Routing and Forwarding table
         </div>
       </div>
 
-      <ExpandableSection title="🐍 Python BGP/MPLS VPN Simulation">
+      <ExpandableSection title="🐍 ELI-Pythonista: BGP/MPLS VPN Simulation">
         <p>
           Let's simulate BGP/MPLS VPN concepts to understand the architecture:
         </p>

--- a/frontend/src/utils/visitHistory.ts
+++ b/frontend/src/utils/visitHistory.ts
@@ -1,0 +1,72 @@
+// Simple utility for tracking RFC visit history in localStorage
+
+const VISIT_HISTORY_KEY = 'rfc-visit-history';
+
+export interface VisitHistory {
+  rfcNumber: number;
+  visitedAt: string; // ISO timestamp
+  visitCount: number;
+}
+
+export const visitHistoryUtils = {
+  // Get all visited RFCs
+  getVisitedRfcs(): VisitHistory[] {
+    try {
+      const stored = localStorage.getItem(VISIT_HISTORY_KEY);
+      return stored ? JSON.parse(stored) : [];
+    } catch (error) {
+      console.error('Error reading visit history:', error);
+      return [];
+    }
+  },
+
+  // Check if an RFC has been visited
+  isRfcVisited(rfcNumber: number): boolean {
+    const visited = this.getVisitedRfcs();
+    return visited.some(visit => visit.rfcNumber === rfcNumber);
+  },
+
+  // Record a visit to an RFC
+  recordVisit(rfcNumber: number): void {
+    try {
+      const visited = this.getVisitedRfcs();
+      const existingIndex = visited.findIndex(visit => visit.rfcNumber === rfcNumber);
+      
+      if (existingIndex >= 0) {
+        // Update existing visit
+        visited[existingIndex].visitedAt = new Date().toISOString();
+        visited[existingIndex].visitCount += 1;
+      } else {
+        // Add new visit
+        visited.push({
+          rfcNumber,
+          visitedAt: new Date().toISOString(),
+          visitCount: 1,
+        });
+      }
+
+      localStorage.setItem(VISIT_HISTORY_KEY, JSON.stringify(visited));
+    } catch (error) {
+      console.error('Error recording visit:', error);
+    }
+  },
+
+  // Get visit statistics
+  getVisitStats() {
+    const visited = this.getVisitedRfcs();
+    return {
+      totalVisited: visited.length,
+      totalVisits: visited.reduce((sum, visit) => sum + visit.visitCount, 0),
+      mostRecentVisit: visited.length > 0 
+        ? visited.reduce((latest, visit) => 
+            new Date(visit.visitedAt) > new Date(latest.visitedAt) ? visit : latest
+          )
+        : null,
+    };
+  },
+
+  // Clear all visit history (for testing/reset)
+  clearHistory(): void {
+    localStorage.removeItem(VISIT_HISTORY_KEY);
+  }
+};


### PR DESCRIPTION
## Summary
- Implement localStorage-based RFC visit tracking system
- Add visual indicators to distinguish between unvisited, visited, and completed RFCs
- Fix RFC2547 section title formatting issue

## Features Added
- **Visit History Tracking**: New `visitHistory.ts` utility manages RFC visit data in localStorage
- **Visual Indicators**: Clear color-coded states for RFC cards:
  - **Unvisited**: Gray FileText icon, default styling
  - **Visited**: Blue Eye icon, blue border/background tint, blue title text
  - **Completed**: Green CheckCircle icon, green border/background tint, green title text
- **Automatic Recording**: Visits are automatically tracked when users navigate to RFC detail pages
- **Consistent Display**: Works in both era-grouped homepage and filtered search results

## Bug Fix
- Fixed RFC2547 Python section title to use proper "ELI-Pythonista" format

## Test Plan
- [x] Build passes without errors
- [x] Visual indicators display correctly for all RFC states
- [x] Visit tracking persists across browser sessions
- [x] History works in both homepage views (era-grouped and filtered)
- [x] No conflicts with existing completion tracking

🤖 Generated with [Claude Code](https://claude.ai/code)